### PR TITLE
Support Django 5.2 and 6.0 and Python 3.10+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,68 +2,49 @@ name: Tests
 
 on:
   push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
-  workflow_dispatch:
-    inputs: {}
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        env: [pytracking]
         include:
-          - python-version: 3.6
-            env: django-dj111
-          - python-version: 3.7
-            env: django-dj111
-          - python-version: 3.6
-            env: django-dj20
-          - python-version: 3.7
-            env: django-dj20
-          - python-version: 3.6
-            env: django-dj21
-          - python-version: 3.7
-            env: django-dj21
-          - python-version: 3.6
-            env: django-dj22
-          - python-version: 3.7
-            env: django-dj22
-          - python-version: 3.8
-            env: django-dj22
-          - python-version: 3.9
-            env: django-dj22
-          - python-version: 3.6
-            env: django-dj30
-          - python-version: 3.7
-            env: django-dj30
-          - python-version: 3.8
-            env: django-dj30
-          - python-version: 3.9
-            env: django-dj30
-          - python-version: 3.6
-            env: django-dj31
-          - python-version: 3.7
-            env: django-dj31
-          - python-version: 3.8
-            env: django-dj31
-          - python-version: 3.9
-            env: django-dj31
+          - python-version: "3.10"
+            toxenv: py310-pytracking
+          - python-version: "3.11"
+            toxenv: py311-pytracking
+          - python-version: "3.12"
+            toxenv: py312-pytracking
+          - python-version: "3.13"
+            toxenv: py313-pytracking
+          - python-version: "3.14"
+            toxenv: py314-pytracking
+          - python-version: "3.10"
+            toxenv: py310-django-dj52
+          - python-version: "3.11"
+            toxenv: py311-django-dj52
+          - python-version: "3.12"
+            toxenv: py312-django-dj52
+          - python-version: "3.13"
+            toxenv: py313-django-dj52
+          - python-version: "3.14"
+            toxenv: py314-django-dj52
+          - python-version: "3.12"
+            toxenv: py312-django-dj60
+          - python-version: "3.13"
+            toxenv: py313-django-dj60
+          - python-version: "3.14"
+            toxenv: py314-django-dj60
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Test with tox and pyenv
-      env:
-        TOXENV: ${{ matrix.env }}
-      run: |
-        tox
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Test with tox
+        run: tox -e ${{ matrix.toxenv }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /build
 *.egg-info
 .idea/
+.venv/
 .tox/
 dist/
 cache/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog - pytracking
 ======================
 
+Unreleased
+---------------------
+
+- Removed django-ipware and now rely on ``REMOTE_ADDR`` to reduce the risk of IP spoofing
+- Updated supported Python versions to 3.10, 3.11, 3.12, 3.13, 3.14
+- Updated supported Django versions to 5.2 and 6.0
+- Updated GitHub Actions test coverage and added Dependabot
+- Fixed tox configuration for the test environments
+
 0.2.2 - November 17th 2020
 --------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Optional Major Features provided by pytracking
 Requirements
 ------------
 
-pytracking works with Python 3.6+. It doesn't require any external library, but
+pytracking works with Python 3.10+. It doesn't require any external library, but
 there are many optional features that have dependencies.
 
 
@@ -448,7 +448,7 @@ Testing pytracking
 pytracking uses `tox <https://tox.readthedocs.io/en/latest/>`_ and `py.test
 <http://docs.pytest.org/en/latest/>`_. If you have tox installed, just run
 ``tox`` and all possible configurations of pytracking will be tested on Python
-3.6-3.9.
+3.10-3.14.
 
 
 TODO

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1
+universal=0

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 EXTRA_REQUIRES = {
-    'test': ['tox>=2.3.1', 'pytest>=2.9.2'],
+    'test': ['tox>=4', 'pytest>=8'],
     'webhook': ['requests>=2.10.0'],
     'html': ['lxml>=3.6.1'],
     'crypto': ['cryptography>=1.4'],
-    'django': ['django>=1.11']
+    'django': ['django>=5.2,<6.1']
 }
 
 ALL_REQUIRE = list(chain(*EXTRA_REQUIRES.values()))
@@ -64,10 +64,13 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
     ],
 
     # What does your project relate to?
@@ -88,6 +91,7 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require=EXTRA_REQUIRES,
+    python_requires='>=3.10',
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -41,7 +41,7 @@ def setup_django():
 
 def test_get_django_request_data(setup_django):
     request = FakeDjangoRequest()
-    request.META["HTTP_X_REAL_IP"] = "10.10.240.22"
+    request.META["REMOTE_ADDR"] = "10.10.240.22"
     request.META["HTTP_USER_AGENT"] = "Firefox"
 
     request_data = tracking_django.get_request_data(request)
@@ -59,7 +59,7 @@ def test_get_tracking_result(setup_django):
         url, base_open_tracking_url=DEFAULT_BASE_OPEN_TRACKING_URL)
 
     request = FakeDjangoRequest()
-    request.META["HTTP_X_REAL_IP"] = "10.10.240.22"
+    request.META["REMOTE_ADDR"] = "10.10.240.22"
     request.META["HTTP_USER_AGENT"] = "Firefox"
 
     tracking_result = tracking_django.get_tracking_result(
@@ -91,7 +91,7 @@ def test_valid_click_tracking_view(setup_django):
     path = get_click_tracking_url_path(url, configuration=configuration)
 
     request = FakeDjangoRequest()
-    request.META["HTTP_X_REAL_IP"] = "10.10.240.22"
+    request.META["REMOTE_ADDR"] = "10.10.240.22"
     request.META["HTTP_USER_AGENT"] = "Firefox"
 
     response = TestClickView.as_view()(request, path)
@@ -185,7 +185,7 @@ def test_valid_open_tracking_view(setup_django):
     path = get_open_tracking_url_path(url, configuration=configuration)
 
     request = FakeDjangoRequest()
-    request.META["HTTP_X_REAL_IP"] = "10.10.240.22"
+    request.META["REMOTE_ADDR"] = "10.10.240.22"
     request.META["HTTP_USER_AGENT"] = "Firefox"
 
     response = TestOpenView.as_view()(request, path)

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,19 @@
 [tox]
 envlist =
-    py{36,37,38,39}-{pytracking},
-    py{36,37}-django-dj{111,20,21},
-    py{36,37,38,39}-django-dj{22,30,31}
+    py{310,311,312,313,314}-pytracking,
+    py{310,311,312,313,314}-django-dj52,
+    py{312,313,314}-django-dj60
 
 [testenv]
 extras =
     test
-    pytracking: crypto,html,webhook
+    pytracking: crypto
+    pytracking: html
+    pytracking: webhook
     django:     django
 commands =
-    pytracking:  py.test --ignore tests/test_django.py
-    django:      py.test tests/test_django.py
+    pytracking:  pytest --ignore tests/test_django.py
+    django:      pytest tests/test_django.py
 deps=
-    dj111: Django>=1.11,<2.0
-    dj20:  Django>=2.0,<2.1
-    dj21:  Django>=2.1,<2.2
-    dj22:  Django>=2.2,<2.3
-    dj30:  Django>=3.0,<3.1
-    dj31:  Django>=3.1,<3.2
+    dj52: Django>=5.2,<5.3
+    dj60: Django>=6.0,<6.1


### PR DESCRIPTION
- Add support for Django 5.2-6.0 and Python 3.10+.
- Drop support for Django <=4.2.
- Update and fixed Django tests to align with previous changes to user IP extraction from Django requests.
- Update and fixed the `tox` configuration.
- Update CHANGELOG.

After merging, a new `0.3.0` release should be published.
